### PR TITLE
Support assets

### DIFF
--- a/source/commands/build/assets.ts
+++ b/source/commands/build/assets.ts
@@ -1,0 +1,9 @@
+import { copy_dir } from "../../deps.ts";
+import { Options } from "../../blog/options.ts";
+
+export const copy_assets = (options: Options) => {
+  return copy_dir({
+    source: `${options.post_source}/../assets`,
+    destination: `${options.post_destination}/assets`,
+  });
+};

--- a/source/commands/build/build.ts
+++ b/source/commands/build/build.ts
@@ -3,6 +3,7 @@ import { get_index } from "../../blog/index.ts";
 import { write_file, create_dir } from "../../deps.ts";
 import { Options } from "../../blog/options.ts";
 import { assemble_html_page, assemble_links } from "./assemble.ts";
+import { copy_assets } from "./assets.ts";
 import { bold, green } from "../../deps.ts";
 import { generate_rss } from "./generate_rss.ts";
 
@@ -11,19 +12,19 @@ const write_posts = async (collection: Collection, options: Options) => {
 
   const style_path = `../`.repeat(collection.level) + options.post_style;
 
-  collection.posts
-    .forEach(async (post) => {
-      const html = await assemble_html_page(
-        post.html,
-        style_path,
-        options.blog_title,
-        options.favicon,
-      );
-      write_file(post.location, html);
-    });
+  collection.posts.forEach(async (post) => {
+    const html = await assemble_html_page(
+      post.html,
+      style_path,
+      options.blog_title,
+      options.favicon
+    );
+    write_file(post.location, html);
+  });
 
-  collection.subcollections
-    .forEach((subcollection) => write_posts(subcollection, options));
+  collection.subcollections.forEach((subcollection) =>
+    write_posts(subcollection, options)
+  );
 };
 
 export const build = async (options: Options) => {
@@ -31,21 +32,24 @@ export const build = async (options: Options) => {
 
   const collection = await get_collection(
     options.post_source,
-    options.post_destination,
+    options.post_destination
   );
   const index = await get_index(collection);
 
   //posts:
   await write_posts(collection, options);
 
+  //assets:
+  await copy_assets(options);
+
   //index
   const links = assemble_links(collection);
   const content = index.main_content.concat(links);
-  const html = await assemble_html_page(
+  const html = assemble_html_page(
     content,
     options.index_style,
     options.blog_title,
-    options.favicon,
+    options.favicon
   );
   write_file("index.html", html);
 

--- a/source/deps.ts
+++ b/source/deps.ts
@@ -16,7 +16,9 @@ export {
   write_file,
   encode,
   decode,
-} from "https://denopkg.com/olaven/dio/mod.ts";
+  copy_dir,
+  dir_exists,
+} from "https://denopkg.com/olaven/dio@v0.1.0/mod.ts";
 
 export { green, red, yellow, bold } from "https://deno.land/std/fmt/colors.ts";
 

--- a/source/rss/converter.ts
+++ b/source/rss/converter.ts
@@ -31,6 +31,7 @@ const get_posts_in_collection = (collection: Collection): Post[] => {
   return posts;
 };
 
+
 //NOTE: exported for testing
 export const get_posts_in_blog = (blog: Blog) =>
   blog.collections


### PR DESCRIPTION
Allows the user to leave assets in `./assets`.
The contents of this folder is copied into the
built blog directory and becomes avaialble for
the HTML files.